### PR TITLE
Added a config option to BearSSL connector

### DIFF
--- a/src/AsyncTelegram.cpp
+++ b/src/AsyncTelegram.cpp
@@ -30,6 +30,7 @@ AsyncTelegram::AsyncTelegram() {
 #if defined(ESP8266) 
     telegramClient.setFingerprint(m_fingerprint);   
     telegramClient.setInsecure();
+    telegramClient.setBufferSizes(1024,1024);
     telegramClient.setNoDelay(true);
 #endif  
 }
@@ -392,6 +393,7 @@ MessageType AsyncTelegram::getNewMessage(TBMessage &message )
 bool AsyncTelegram::begin(){
 #if defined(ESP8266)
     telegramClient.setInsecure();
+    telegramClient.setBufferSizes(1024,1024);
     telegramClient.setNoDelay(true);
 #elif defined(ESP32)
     //Start Task with input parameter set to "this" class


### PR DESCRIPTION
This setBufferSizes(1024,1024) will limit the memory impact of the connector by limiting SSL buffer size to 1kb.
It should be mentioned that this works because telegram server allows it.